### PR TITLE
OrderItemの存在しない出荷を事前に削除するよう修正

### DIFF
--- a/codeception/acceptance/EA09ShippingCest.php
+++ b/codeception/acceptance/EA09ShippingCest.php
@@ -20,6 +20,10 @@ class EA09ShippingCest
         // すべてのテストケース実施前にログインしておく
         // ログイン後は管理アプリのトップページに遷移している
         $I->loginAsAdmin();
+
+        // shipping一括発送済み更新が失敗してしまうため、OrderItemの存在しない出荷を削除しておく
+        $deleteShippingNotExistsOfItem = Fixtures::get('deleteShippingNotExistsOfItem'); // Closure
+        $deleteShippingNotExistsOfItem();
     }
 
     public function _after(\AcceptanceTester $I)
@@ -174,7 +178,7 @@ class EA09ShippingCest
         $I->wait(5);
         $I->waitForElementVisible(['xpath' => '//*[@id="sentUpdateModal"]/div/div/div[2]/p']);
         $I->see('処理完了', ['xpath' => '//*[@id="sentUpdateModal"]/div/div/div[2]/p']);
-        $I->seeEmailCount(18);  // XXX 何故か travis では 18 になる
+        $I->seeEmailCount(20);
 
         $I->click(['id' => 'bulkChangeComplete']);
     }

--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -221,6 +221,26 @@ $resetShippingStatusPrepared = function () use ($entityManager) {
 /** 出荷準備中に更新するクロージャ. */
 Fixtures::add('resetShippingStatusPrepared', $resetShippingStatusPrepared);
 
+$deleteShippingNotExistsOfItem = function () use ($entityManager) {
+    $sub = $entityManager->getRepository('Eccube\Entity\OrderItem')
+        ->createQueryBuilder('oi');
+    $sub->select('oi')
+        ->andWhere('oi.Shipping = s.id');
+    $qb = $entityManager->getRepository('Eccube\Entity\Shipping')
+        ->createQueryBuilder('s');
+    $qb->select('s')
+    ->andWhere($qb->expr()->not($qb->expr()->exists($sub->getDQL())));
+    $Shippings = $qb->getQuery()->getResult();
+
+    foreach ($Shippings as $Shipping) {
+        $entityManager->remove($Shipping);
+    }
+    $entityManager->flush();
+    return true;
+};
+/** OrderItemの存在しない出荷を削除するクロージャ. */
+Fixtures::add('deleteShippingNotExistsOfItem', $deleteShippingNotExistsOfItem);
+
 $findProducts = function () use ($entityManager) {
     return $entityManager->getRepository('Eccube\Entity\Product')
         ->createQueryBuilder('p')

--- a/codeception/acceptance/config.ini
+++ b/codeception/acceptance/config.ini
@@ -4,5 +4,5 @@ admin_password = 'password'
 fixture_customer_num = 10    ; 各カスタマー作成時に注文を1つづつつくる。さらに、注文を作る際に1つ商品を作る
                             ; フロント側のテストとして3以上が必要
 fixture_product_num = 20
-fixture_order_num = 20
+fixture_order_num = 25
 hostname = 'eccube3' ; 対象EC-CUBE3が稼働しているサーバーのホスト名


### PR DESCRIPTION
shipping一括発送済み更新が失敗してしまうため、OrderItemの存在しない出荷を削除しておくようにしました

see https://github.com/EC-CUBE/ec-cube/pull/3062#issuecomment-381534888

