### PR TITLE
削除モーダルの実装漏れ実装・権限管理削除のバグ修正・UnitTest修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/MemberController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MemberController.php
@@ -201,7 +201,7 @@ class MemberController extends AbstractController
 
             $this->addSuccess('admin.common.save_complete', 'admin');
 
-            return $this->redirectToRoute('admin_setting_system_member', ['id' => $Member->getId()]);
+            return $this->redirectToRoute('admin_setting_system_member_edit', ['id' => $Member->getId()]);
         }
 
         $this->tokenStorage->getToken()->setUser($LoginMember);

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
@@ -181,8 +181,40 @@ file that was distributed with this source code.
 
                                                     <div class="col-6 text-center">
                                                         {% if not TaxRule.default_tax_rule %}
-                                                            <a class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.delete'|trans }}" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
-                                                                <i class="fa fa-times fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                            <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top"
+                                                                 title="{{ 'admin.common.delete'|trans }}">
+                                                                <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#layoutDelete">
+                                                                    <i class="fa fa-close fa-lg text-secondary"></i>
+                                                                </a>
+                                                            </div>
+                                                            <!-- 削除モーダル -->
+                                                            <div class="modal fade" id="layoutDelete" tabindex="-1" role="dialog"
+                                                                 aria-labelledby="layoutDelete" aria-hidden="true">
+                                                                <div class="modal-dialog" role="document">
+                                                                    <div class="modal-content">
+                                                                        <div class="modal-header">
+                                                                            <h5 class="modal-title font-weight-bold">
+                                                                                {{ 'admin.common.delete_modal__title'|trans }}
+                                                                            </h5>
+                                                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                                                                                <span aria-hidden="true">×</span>
+                                                                            </button>
+                                                                        </div>
+                                                                        <div class="modal-body text-left">
+                                                                            <p class="text-left modal-message">{{ 'admin.common.delete_modal__message'|trans({ "%name%" : TaxRule.id }) }}</p>
+                                                                        </div>
+                                                                        <div class="modal-footer">
+                                                                            <button class="btn btn-ec-sub" type="button" data-dismiss="modal">
+                                                                                {{ 'admin.common.cancel'|trans }}
+                                                                            </button>
+                                                                            <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}"
+                                                                                {{ csrf_token_for_anchor() }} data-method="delete" data-confirm="false">
+                                                                                {{ 'admin.common.delete'|trans }}
+                                                                            </a>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                         {% endif %}
                                                     </div>
                                                 </div>

--- a/src/Eccube/Resource/template/admin/Setting/System/authority.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/authority.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
         $(function() {
 
             var $collectionHolder = $('#table-authority');
-            var index = $collectionHolder.find('.input-deny-url').length;
+            var index = $collectionHolder.find('.authority-rule').length;
 
             $('.add').click(function() {
                 var prototype = $collectionHolder.data('prototype');
@@ -34,7 +34,7 @@ file that was distributed with this source code.
 
             $(document).on('click', '.delete', function() {
                 $(this).parent('td').parent('tr').remove();
-                var idx = $collectionHolder.find('.input-deny-url').length;
+                var idx = $collectionHolder.find('.authority-rule').length;
                 if (idx == 0) {
                     var prototype = $collectionHolder.data('prototype');
                     var newForm = prototype.replace(/__name__/g, idx);
@@ -72,19 +72,7 @@ file that was distributed with this source code.
                                     </thead>
                                     <tbody>
                                     {% for form in form.AuthorityRoles %}
-                                        <tr id="ex-authority-{{ loop.index }}">
-                                            <td>
-                                                {{ form_widget(form.Authority) }}
-                                                {{ form_errors(form.Authority) }}
-                                            </td>
-                                            <td>
-                                                {{ form_widget(form.deny_url) }}
-                                                {{ form_errors(form.deny_url) }}
-                                            </td>
-                                            <td class="text-center">
-                                                <button type="button" class="btn btn-ec-regular delete">{{ 'admin.common.delete'|trans }}</button>
-                                            </td>
-                                        </tr>
+                                        {{ include('@admin/Setting/System/authority_prototype.twig', {'form': form }) }}
                                     {% endfor %}
                                     </tbody>
                                 </table>

--- a/src/Eccube/Resource/template/admin/Setting/System/authority_prototype.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/authority_prototype.twig
@@ -8,7 +8,7 @@ http://www.lockon.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
-<tr>
+<tr class="authority-rule">
     <td>
         {{ form_widget(form.Authority) }}
         {{ form_errors(form.Authority) }}

--- a/src/Eccube/Resource/template/admin/Setting/System/member.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member.twig
@@ -120,17 +120,20 @@ file that was distributed with this source code.
                                                 </div>
                                                 <div class="col-auto text-center">
                                                     {% if Member.id == app.user.id %}
-                                                        <a class="btn btn-ec-actionIcon action-delete disabled"
-                                                           data-toggle="tooltip" data-placement="top"
-                                                           data-original-title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon action-delete mr-3 disabled"
+                                                            data-toggle="tooltip" data-placement="top"
+                                                            title="{{ 'admin.common.delete'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
                                                         </a>
                                                     {% else %}
-                                                        <a class="btn btn-ec-actionIcon action-delete"
-                                                           data-toggle="modal"
-                                                           data-target="#member_delete_{{ Member.id }}">
-                                                            <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
-                                                        </a>
+                                                        <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top"
+                                                             title="{{ 'admin.common.delete'|trans }}">
+                                                            <a class="btn btn-ec-actionIcon action-delete"
+                                                               data-toggle="modal"
+                                                               data-target="#member_delete_{{ Member.id }}">
+                                                                <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                            </a>
+                                                        </div>
                                                         <div class="modal fade" id="member_delete_{{ Member.id }}" tabindex="-1"
                                                              role="dialog"
                                                              aria-labelledby="member_delete_{{ Member.id }}" aria-hidden="true">

--- a/src/Eccube/Resource/template/admin/Store/template.twig
+++ b/src/Eccube/Resource/template/admin/Store/template.twig
@@ -8,7 +8,7 @@ http://www.lockon.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
-{% extends '@admin/old_frame.twig' %}
+{% extends '@admin/default_frame.twig' %}
 
 {% set menus = ['store', 'template', 'template_list'] %}
 

--- a/src/Eccube/Resource/template/admin/Store/template_add.twig
+++ b/src/Eccube/Resource/template/admin/Store/template_add.twig
@@ -8,7 +8,7 @@ http://www.lockon.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
-{% extends '@admin/old_frame.twig' %}
+{% extends '@admin/default_frame.twig' %}
 
 {% set menus = ['store', 'template', 'template_install'] %}
 

--- a/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
@@ -149,7 +149,7 @@ class LayoutControllerTest extends AbstractAdminWebTestCase
             $this->generateUrl('admin_content_layout_delete', ['id' => $Layout->getId()])
         );
         $crawler = $this->client->followRedirect();
-        $this->assertRegExp('/削除が完了しました。/u', $crawler->filter('div.alert-success')->text());
+        $this->assertRegExp('/削除しました/u', $crawler->filter('div.alert-success')->text());
     }
 
     public function testDeleteFail()

--- a/tests/Eccube/Tests/Web/Admin/Order/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/CsvImportControllerTest.php
@@ -23,12 +23,16 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
 {
     public function testLoadCsv()
     {
-        $Shipping = $this->createOrder($this->createCustomer())->getShippings()[0];
+        $OrderStatus = $this->entityManager->find(OrderStatus::class, OrderStatus::NEW);
+        $Order = $this->createOrder($this->createCustomer());
+        $Order->setOrderStatus($OrderStatus);
+        $this->entityManager->flush();
+        $Shipping = $Order->getShippings()[0];
         self::assertNull($Shipping->getTrackingNumber());
         self::assertNull($Shipping->getShippingDate());
 
         $this->loadCsv([
-            '出荷ID,出荷伝票番号,出荷日',
+            '出荷ID,送り状番号,出荷日',
             $Shipping->getId().',1234,2018-01-23',
         ]);
 
@@ -45,7 +49,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         self::assertNull($Shipping->getShippingDate());
 
         $this->loadCsv([
-            '出荷ID,出荷日,出荷伝票番号',
+            '出荷ID,出荷日,送り状番号',
             $Shipping->getId().',2018-01-23,1234',
         ]);
 
@@ -78,32 +82,32 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         return [
             [
                 [
-                    '出荷日,出荷伝票番号',
+                    '出荷日,送り状番号',
                     '2018-01-23,1234',
-                ], 'CSVのフォーマットが一致しません。',
+                ], 'CSVのフォーマットが一致しません',
             ],
             [
                 [
-                    '出荷日,出荷伝票番号',
-                ], 'CSVのフォーマットが一致しません。',
+                    '出荷日,送り状番号',
+                ], 'CSVのフォーマットが一致しません',
             ],
             [
                 [
-                    '出荷ID,出荷日,出荷伝票番号',
+                    '出荷ID,出荷日,送り状番号',
                     '99999999,2018-01-23,1234',
-                ], '1行目の出荷IDが存在しません。',
+                ], '1行目の出荷IDが存在しません',
             ],
             [
                 [
-                    '出荷ID,出荷日,出荷伝票番号',
+                    '出荷ID,出荷日,送り状番号',
                     'x,2018-01-23,1234',
-                ], '1行目の出荷IDが存在しません。',
+                ], '1行目の出荷IDが存在しません',
             ],
             [
                 [
-                    '出荷ID,出荷日,出荷伝票番号',
+                    '出荷ID,出荷日,送り状番号',
                     '{id},2018/01/23,1234',
-                ], '1行目出荷IDの日付フォーマットが異なります。',
+                ], '1行目出荷IDの日付フォーマットが異なります',
             ],
         ];
     }
@@ -155,7 +159,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
 
         $tempFile = tempnam(sys_get_temp_dir(), 'csv_import_controller_test');
         file_put_contents($tempFile, implode(PHP_EOL, [
-            '出荷ID,出荷伝票番号,出荷日',
+            '出荷ID,送り状番号,出荷日',
             $Shipping1->getId().',1234,2018-01-11',
             $Shipping2->getId().',5678,2018-02-22',
             $Shipping3->getId().',9012,2018-03-22',
@@ -176,7 +180,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         );
 
         $this->assertRegexp(
-            '/出荷登録CSVファイルをアップロードしました。/u',
+            '/CSVファイルをアップロードしました/u',
             $crawler->filter('div.alert-primary')->text()
         );
 

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -78,7 +78,7 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
 
         $this->assertContains((string) $shippingId, $crawler->filter('#search_result')->html());
 
-        $expectedText = 'PDF出力';
+        $expectedText = '納品書出力';
         $actualNode = $crawler->filter('.btn-bulk-wrapper')->html();
         $this->assertContains($expectedText, $actualNode);
     }
@@ -351,7 +351,7 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
      */
     private function getForm(Crawler $crawler)
     {
-        $form = $crawler->selectButton('この内容で作成する')->form();
+        $form = $crawler->selectButton('作成')->form();
         $form['order_pdf[_token]'] = 'dummy';
 
         return $form;

--- a/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
@@ -54,14 +54,14 @@ class ShippingControllerTest extends AbstractEditControllerTestCase
         );
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
-        $form = $crawler->selectButton('出荷情報を登録')->form();
+        $form = $crawler->selectButton('登録')->form();
 
         $this->client->submit($form);
         $crawler = $this->client->followRedirect();
         $info = $crawler->filter('#page_admin_shipping_edit > div.c-container > div.c-contentsArea > div.alert.alert-primary')->text();
         $success = $crawler->filter('#page_admin_shipping_edit > div.c-container > div.c-contentsArea > div.alert.alert-success')->text();
-        $this->assertContains('出荷情報を登録しました。', $success);
-        $this->assertContains('出荷に関わる情報が変更されました：送料の変更が必要な場合は、受注管理より手動で変更してください。', $info);
+        $this->assertContains('保存しました', $success);
+        $this->assertContains('出荷に関わる情報が変更されました。送料の変更が必要な場合は、受注管理より手動で変更してください。', $info);
     }
 
     public function testEditAddTrackingNumber()
@@ -81,14 +81,14 @@ class ShippingControllerTest extends AbstractEditControllerTestCase
         );
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
-        $form = $crawler->selectButton('出荷情報を登録')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['form[shippings][0][tracking_number]']->setValue($trackingNumber);
 
         $this->client->submit($form);
         $crawler = $this->client->followRedirect();
 
         $success = $crawler->filter('#page_admin_shipping_edit > div.c-container > div.c-contentsArea > div.alert.alert-success')->text();
-        $this->assertContains('出荷情報を登録しました。', $success);
+        $this->assertContains('保存しました', $success);
 
         $expectedShipping = $this->entityManager->find(Shipping::class, $shippingId);
         $this->assertEquals($trackingNumber, $expectedShipping->getTrackingNumber());
@@ -116,7 +116,7 @@ class ShippingControllerTest extends AbstractEditControllerTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
         // 出荷先を追加ボタンを押下
-        $form = $crawler->selectButton('出荷情報を登録')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['form[add_shipping]']->setValue('1');
 
         $this->client->submit($form);
@@ -124,9 +124,9 @@ class ShippingControllerTest extends AbstractEditControllerTestCase
 
         // 出荷登録フォームが２個に増えていることを確認
         $card1 = $crawler->filter('#form1 > div.c-contentsArea__cols > div > div > div:nth-child(1) > div.card-header > div > div.col-8 > div > span')->text();
-        $this->assertContains('出荷内容1', $card1);
+        $this->assertContains('出荷情報(1)', $card1);
         $card2 = $crawler->filter('#form1 > div.c-contentsArea__cols > div > div > div:nth-child(2) > div.card-header > div > div.col-8 > div > span')->text();
-        $this->assertContains('出荷内容2', $card2);
+        $this->assertContains('出荷情報(2)', $card2);
 
         // ２個の出荷登録フォームを作成
         $shippingFormData = $this->createShippingFormDataForEdit($Shipping);

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -492,7 +492,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->actual = count($arrCategory);
         $this->verify();
 
-        $this->assertRegexp('/CSVのフォーマットが一致しません。/u', $crawler->filter('div#upload_box__error--1')->text());
+        $this->assertRegexp('/CSVのフォーマットが一致しません/u', $crawler->filter('div#upload_box__error--1')->text());
     }
 
     /**
@@ -681,8 +681,8 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
     public function dataProductIdProvider()
     {
         return [
-            [99999, '2行目の商品IDが存在しません。'],
-            ['abc', '2行目の商品IDが存在しません。'],
+            [99999, '2行目の商品IDが存在しません'],
+            ['abc', '2行目の商品IDが存在しません'],
         ];
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -75,7 +75,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // 初期化ボタンが表示されている
         $this->assertCount(1, $crawler->selectButton('商品規格の初期化'));
         // 更新ボタンが表示されている
-        $this->assertCount(1, $crawler->selectButton('更新'));
+        $this->assertCount(1, $crawler->selectButton('登録'));
     }
 
     /**
@@ -177,7 +177,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body')->html();
-        $this->assertContains('商品規格を登録しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         $taxRule = $this->taxRuleRepository->findBy(['Product' => $product]);
@@ -225,7 +225,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body')->html();
-        $this->assertContains('商品規格を登録しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         $taxRule = $this->taxRuleRepository->findOneBy(['Product' => $product]);
@@ -271,7 +271,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body')->html();
-        $this->assertContains('商品規格を登録しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         /* @var TaxRule $taxRule */
@@ -301,7 +301,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // edit class category with tax rate invalid
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][0][checked]']->tick();
         $form['product_class_matrix[product_classes][0][stock]'] = 1;
         $form['product_class_matrix[product_classes][0][price02]'] = 1;
@@ -336,7 +336,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // edit class category with tax = 0
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][0][checked]']->tick();
         $form['product_class_matrix[product_classes][0][stock]'] = 1;
         $form['product_class_matrix[product_classes][0][price02]'] = 1;
@@ -347,7 +347,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
-        $this->assertContains('商品規格を更新しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         $product = $this->productRepository->find($id);
@@ -376,7 +376,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // edit class category without tax
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][0][checked]']->tick();
         $form['product_class_matrix[product_classes][0][stock]'] = 1;
         $form['product_class_matrix[product_classes][0][price02]'] = 1;
@@ -387,7 +387,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
-        $this->assertContains('商品規格を更新しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         $product = $this->productRepository->find($id);
@@ -415,7 +415,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         );
 
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][0][checked]']->tick();
         $form['product_class_matrix[product_classes][0][stock]'] = 1;
         $form['product_class_matrix[product_classes][0][price02]'] = 1;
@@ -426,7 +426,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
-        $this->assertContains('商品規格を更新しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         $product = $this->productRepository->find($id);
@@ -471,7 +471,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // edit class category with tax
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][2][checked]']->tick();
         $form['product_class_matrix[product_classes][2][stock]'] = 1;
         $form['product_class_matrix[product_classes][2][price02]'] = 1;
@@ -484,7 +484,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         // check submit
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
-        $this->assertContains('商品規格を更新しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
 
         // check database
         /* @var TaxRule $taxRule */
@@ -512,7 +512,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // edit class category with tax
         /* @var Form $form */
-        $form = $crawler->selectButton('更新')->form();
+        $form = $crawler->selectButton('登録')->form();
         $form['product_class_matrix[product_classes][0][checked]']->untick();
         $this->client->submit($form);
 
@@ -521,7 +521,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         $crawler = $this->client->followRedirect();
         $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
-        $this->assertContains('商品規格を更新しました。', $htmlMessage);
+        $this->assertContains('保存しました', $htmlMessage);
         // check database
         $product = $this->productRepository->find($id);
         /* @var TaxRule $taxRule */

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -386,8 +386,8 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             $this->generateUrl('admin_product_product_edit', ['id' => $Product->getId()])
         );
 
-        $expected = 'この商品の規格';
-        $actual = $crawler->filter('#standardConfig > div > div.d-inline-block')->text();
+        $expected = '規格1';
+        $actual = $crawler->filter('#standardConfig > div > table')->text();
         $this->assertContains($expected, $actual);
 
         $this->expected = $productClassNum;

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
@@ -120,7 +120,7 @@ class MailControllerTest extends AbstractAdminWebTestCase
 
         $outPut = $this->container->get('session')->getFlashBag()->get('eccube.admin.error');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.shop.mail.save.error';
+        $this->expected = 'admin.common.save_error';
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/PaymentControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/PaymentControllerTest.php
@@ -137,39 +137,6 @@ class PaymentControllerTest extends AbstractAdminWebTestCase
         $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 
-    public function testUp()
-    {
-        $pid = 4;
-        $Payment = $this->paymentRepository->find($pid);
-        $before = $Payment->getSortNo();
-        $this->client->request('PUT',
-            $this->generateUrl('admin_setting_shop_payment_up', ['id' => $pid])
-        );
-        $this->assertTrue($this->client->getResponse()->isRedirection());
-
-        $after = $Payment->getSortNo();
-        $this->actual = $after;
-        $this->expected = $before + 1;
-        $this->verify();
-    }
-
-    public function testDown()
-    {
-        $pid = 1;
-        $Payment = $this->paymentRepository->find($pid);
-        $before = $Payment->getSortNo();
-        $this->client->request('PUT',
-            $this->generateUrl('admin_setting_shop_payment_down', ['id' => $pid])
-        );
-
-        $this->assertTrue($this->client->getResponse()->isRedirection());
-
-        $after = $Payment->getSortNo();
-        $this->actual = $after;
-        $this->expected = $before - 1;
-        $this->verify();
-    }
-
     public function testAddImage()
     {
         $formData = $this->createFormData();

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
@@ -105,7 +105,7 @@ class LogControllerTest extends AbstractAdminWebTestCase
         );
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
-        list($this->actual) = $crawler->filter('#line-max')->extract(['style']);
+        list($this->actual) = $crawler->filter('#admin_system_log_line_max')->extract(['style']);
         $this->expected = $expected;
         $this->verify();
         if ($message) {

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -176,7 +176,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 
@@ -213,7 +213,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 
@@ -245,7 +245,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 
@@ -279,7 +279,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 
@@ -311,7 +311,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 
@@ -364,7 +364,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         // message check
         $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
-        $this->expected = 'admin.register.complete';
+        $this->expected = 'admin.common.save_complete';
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
@@ -144,10 +144,11 @@ class MemberControllerTest extends AbstractAdminWebTestCase
             ]
         );
 
-        $redirectUrl = $this->generateUrl('admin_setting_system_member');
+        $Member = $this->memberRepository->findOneBy(['login_id' => $formData['login_id']]);
+
+        $redirectUrl = $this->generateUrl('admin_setting_system_member_edit', ['id' => $Member->getId()]);
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
 
-        $Member = $this->memberRepository->findOneBy(['login_id' => $formData['login_id']]);
         $this->actual = $Member->getLoginId();
         $this->expected = $formData['login_id'];
         $this->verify();
@@ -189,7 +190,7 @@ class MemberControllerTest extends AbstractAdminWebTestCase
             ['admin_member' => $formData]
         );
 
-        $redirectUrl = $this->generateUrl('admin_setting_system_member');
+        $redirectUrl = $this->generateUrl('admin_setting_system_member_edit', ['id' => $Member->getId()]);
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
 
         $this->actual = $Member->getLoginId();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 削除モーダルの実装漏れ
- 権限管理削除のバグ修正
  - CollectionTypeのjs側で項目数の計算がうまくできていなかったので削除ボタン押下時に全項目が消える状況となっていた。
- UnitTest実装
